### PR TITLE
DSND-1267 Delete delta handle illegal arg

### DIFF
--- a/src/main/java/uk/gov/companieshouse/exemptions/delta/delete/DeleteClient.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/delta/delete/DeleteClient.java
@@ -27,8 +27,8 @@ class DeleteClient {
     /**
      * Delete a company exemptions resource via a REST HTTP request.
      *
-     * @param request A {@link DeleteRequest request object} containing data that will be upserted and the path to which
-     *                it will be sent.
+     * @param request A {@link DeleteRequest request object} containing the path to which the delete
+     *                request will be sent.
      */
     void delete(DeleteRequest request) {
         InternalApiClient client = internalApiClientFactory.get();
@@ -41,7 +41,7 @@ class DeleteClient {
                 logger.error(String.format("Server error returned with status code: [%s] when deleting delta", e.getStatusCode()));
                 throw new RetryableException("Server error returned when deleting delta", e);
             } else {
-                logger.error(String.format("Upsert client error returned with status code: [%s] when deleting delta", e.getStatusCode()));
+                logger.error(String.format("Delete client error returned with status code: [%s] when deleting delta", e.getStatusCode()));
                 throw new NonRetryableException("DeleteClient error returned when deleting delta", e);
             }
         } catch (IllegalArgumentException e) {

--- a/src/main/java/uk/gov/companieshouse/exemptions/delta/delete/DeleteClient.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/delta/delete/DeleteClient.java
@@ -8,6 +8,7 @@ import uk.gov.companieshouse.exemptions.delta.NonRetryableException;
 import uk.gov.companieshouse.exemptions.delta.RetryableException;
 
 import java.util.function.Supplier;
+import uk.gov.companieshouse.logging.Logger;
 
 /**
  * Deletes a company exemptions resource via a REST HTTP request.
@@ -16,9 +17,11 @@ import java.util.function.Supplier;
 class DeleteClient {
 
     private final Supplier<InternalApiClient> internalApiClientFactory;
+    private final Logger logger;
 
-    DeleteClient(Supplier<InternalApiClient> internalApiClientFactory) {
+    DeleteClient(Supplier<InternalApiClient> internalApiClientFactory, Logger logger) {
         this.internalApiClientFactory = internalApiClientFactory;
+        this.logger = logger;
     }
 
     /**
@@ -28,18 +31,24 @@ class DeleteClient {
      *                it will be sent.
      */
     void delete(DeleteRequest request) {
+        InternalApiClient client = internalApiClientFactory.get();
         try {
-            InternalApiClient client = internalApiClientFactory.get();
             client.privateDeltaCompanyAppointmentResourceHandler()
                     .deleteCompanyExemptionsResource(request.getPath())
                     .execute();
         } catch (ApiErrorResponseException e) {
             if (e.getStatusCode() / 100 == 5) {
+                logger.error(String.format("Server error returned with status code: [%s] when deleting delta", e.getStatusCode()));
                 throw new RetryableException("Server error returned when deleting delta", e);
             } else {
+                logger.error(String.format("Upsert client error returned with status code: [%s] when deleting delta", e.getStatusCode()));
                 throw new NonRetryableException("DeleteClient error returned when deleting delta", e);
             }
+        } catch (IllegalArgumentException e) {
+            logger.error("Illegal argument exception caught when handling API response");
+            throw new RetryableException("Server error returned when deleting delta", e);
         } catch (URIValidationException e) {
+            logger.error("Invalid path specified when handling API request");
             throw new NonRetryableException("Invalid path specified", e);
         }
     }

--- a/src/test/java/uk/gov/companieshouse/exemptions/delta/delete/ClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/delta/delete/ClientTest.java
@@ -14,6 +14,7 @@ import uk.gov.companieshouse.api.handler.delta.exemptions.request.PrivateCompany
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.exemptions.delta.NonRetryableException;
 import uk.gov.companieshouse.exemptions.delta.RetryableException;
+import uk.gov.companieshouse.logging.Logger;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -38,13 +39,16 @@ public class ClientTest {
     @Mock
     private PrivateCompanyExemptionsDelete deleteHandler;
 
+    @Mock
+    private Logger logger;
+
     @Test
     void testDelete() throws ApiErrorResponseException, URIValidationException {
         // given
         when(internalApiClient.privateDeltaCompanyAppointmentResourceHandler()).thenReturn(resourceHandler);
         when(resourceHandler.deleteCompanyExemptionsResource(any())).thenReturn(deleteHandler);
         DeleteRequest request = new DeleteRequest(REQUEST_PATH);
-        DeleteClient client = new DeleteClient(() -> internalApiClient);
+        DeleteClient client = new DeleteClient(() -> internalApiClient, logger);
 
         // when
         client.delete(request);
@@ -61,7 +65,7 @@ public class ClientTest {
         when(resourceHandler.deleteCompanyExemptionsResource(any())).thenReturn(deleteHandler);
         when(deleteHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(400, "Bad request", new HttpHeaders())));
         DeleteRequest request = new DeleteRequest(REQUEST_PATH);
-        DeleteClient client = new DeleteClient(() -> internalApiClient);
+        DeleteClient client = new DeleteClient(() -> internalApiClient, logger);
 
         // when
         Executable actual = () -> client.delete(request);
@@ -79,7 +83,7 @@ public class ClientTest {
         when(resourceHandler.deleteCompanyExemptionsResource(any())).thenReturn(deleteHandler);
         when(deleteHandler.execute()).thenThrow(URIValidationException.class);
         DeleteRequest request = new DeleteRequest("invalid");
-        DeleteClient client = new DeleteClient(() -> internalApiClient);
+        DeleteClient client = new DeleteClient(() -> internalApiClient, logger);
 
         // when
         Executable actual = () -> client.delete(request);
@@ -97,7 +101,7 @@ public class ClientTest {
         when(resourceHandler.deleteCompanyExemptionsResource(any())).thenReturn(deleteHandler);
         when(deleteHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(503, "Service unavailable", new HttpHeaders())));
         DeleteRequest request = new DeleteRequest(REQUEST_PATH);
-        DeleteClient client = new DeleteClient(() -> internalApiClient);
+        DeleteClient client = new DeleteClient(() -> internalApiClient, logger);
 
         // when
         Executable actual = () -> client.delete(request);


### PR DESCRIPTION
* Adds a catch block to handle illegal argument exceptions thrown when sending delete requests.
* Adds log messages to each branch of possible responses from the API.

[DSND-1267](https://companieshouse.atlassian.net/browse/DSND-1267)