### PR TITLE
DSND-1437 Fix deserialisation indefinite loop

### DIFF
--- a/src/main/java/uk/gov/companieshouse/exemptions/delta/ChsDeltaDeserialiser.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/delta/ChsDeltaDeserialiser.java
@@ -36,9 +36,8 @@ public class ChsDeltaDeserialiser implements Deserializer<ChsDelta> {
             DatumReader<ChsDelta> reader = new ReflectDatumReader<>(ChsDelta.class);
             return reader.read(null, decoder);
         } catch (IOException | AvroRuntimeException e) {
-            LOGGER.error("Error deserialising message FOUR", e);
-            //TODO custom exception? i.e. InvalidPayloadException
-            throw new RuntimeException(e);
+            LOGGER.error("Error deserialising message.", e);
+            throw new InvalidPayloadException("Invalid payload was provided.", e);
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/exemptions/delta/ChsDeltaDeserialiser.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/delta/ChsDeltaDeserialiser.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.exemptions.delta;
 
-import java.io.UncheckedIOException;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
@@ -37,7 +36,7 @@ public class ChsDeltaDeserialiser implements Deserializer<ChsDelta> {
             return reader.read(null, decoder);
         } catch (IOException | AvroRuntimeException e) {
             LOGGER.error("Error deserialising message.", e);
-            throw new InvalidPayloadException("Invalid payload was provided.", e);
+            throw new InvalidPayloadException(String.format("Invalid payload: [%s] was provided.", new String(data)), e);
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/exemptions/delta/ChsDeltaDeserialiser.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/delta/ChsDeltaDeserialiser.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.exemptions.delta;
 
+import java.io.UncheckedIOException;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
@@ -36,7 +37,8 @@ public class ChsDeltaDeserialiser implements Deserializer<ChsDelta> {
             return reader.read(null, decoder);
         } catch (IOException | AvroRuntimeException e) {
             LOGGER.error("Error deserialising message FOUR", e);
-            return null;
+            //TODO custom exception? i.e. InvalidPayloadException
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/exemptions/delta/ChsDeltaDeserialiser.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/delta/ChsDeltaDeserialiser.java
@@ -35,7 +35,7 @@ public class ChsDeltaDeserialiser implements Deserializer<ChsDelta> {
             DatumReader<ChsDelta> reader = new ReflectDatumReader<>(ChsDelta.class);
             return reader.read(null, decoder);
         } catch (IOException | AvroRuntimeException e) {
-            LOGGER.error("Error deserialising message", e);
+            LOGGER.error("Error deserialising message FOUR", e);
             return null;
         }
     }

--- a/src/main/java/uk/gov/companieshouse/exemptions/delta/Config.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/delta/Config.java
@@ -20,6 +20,7 @@ import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.util.backoff.FixedBackOff;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.delta.ChsDelta;
@@ -38,11 +39,13 @@ public class Config {
     public ConsumerFactory<String, ChsDelta> consumerFactory(@Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
         return new DefaultKafkaConsumerFactory<>(new HashMap<>() {{
             put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-            put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-            put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ChsDeltaDeserialiser.class);
+            put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+            put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+            put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
+            put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, ChsDeltaDeserialiser.class);
             put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
             put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
-        }}, new StringDeserializer(), new ChsDeltaDeserialiser());
+        }}, new StringDeserializer(), new ErrorHandlingDeserializer<>(new ChsDeltaDeserialiser()));
     }
 
     @Bean

--- a/src/main/java/uk/gov/companieshouse/exemptions/delta/InvalidMessageRouter.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/delta/InvalidMessageRouter.java
@@ -1,5 +1,8 @@
 package uk.gov.companieshouse.exemptions.delta;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Base64;
 import org.apache.kafka.clients.producer.ProducerInterceptor;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -21,9 +24,20 @@ public class InvalidMessageRouter implements ProducerInterceptor<String, ChsDelt
             messageFlags.destroy();
             return record;
         } else {
-            ProducerRecord invalidRecord = new ProducerRecord<>(invalidMessageTopic, record.key(), record.value());
+            ObjectMapper mapper = new ObjectMapper();
+            String dataMessage = "";
+            try {
+                byte[] stringBytes = mapper.writeValueAsBytes(record.value().getData());
+                dataMessage = Base64.getEncoder().encodeToString(stringBytes);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+            }
+            LOGGER.info("HELLO WORLD1");
+            //TODO capture as much metadata as possible.
+            ChsDelta invalidData = new ChsDelta(dataMessage, 0, "context_id", false);
+            ProducerRecord<String, ChsDelta> invalidRecord = new ProducerRecord<>(invalidMessageTopic, record.key(), invalidData);
             LOGGER.info(String.format("Moving record into topic: [%s]\nMessage content: %s",
-                    invalidRecord.topic(), invalidRecord.value()));
+                    invalidRecord.topic(), dataMessage));
             return invalidRecord;
         }
     }

--- a/src/main/java/uk/gov/companieshouse/exemptions/delta/InvalidMessageRouter.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/delta/InvalidMessageRouter.java
@@ -27,7 +27,7 @@ public class InvalidMessageRouter implements ProducerInterceptor<String, ChsDelt
             ObjectMapper mapper = new ObjectMapper();
             String dataMessage = "";
             try {
-                byte[] stringBytes = mapper.writeValueAsBytes(record.value().getData());
+                byte[] stringBytes = mapper.writeValueAsBytes(record.value());
                 dataMessage = Base64.getEncoder().encodeToString(stringBytes);
             } catch (JsonProcessingException e) {
                 e.printStackTrace();

--- a/src/main/java/uk/gov/companieshouse/exemptions/delta/InvalidPayloadException.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/delta/InvalidPayloadException.java
@@ -1,0 +1,11 @@
+package uk.gov.companieshouse.exemptions.delta;
+
+/**
+ * Exception to handle when an invalid payload is sent to the kafka topic.
+ */
+public class InvalidPayloadException extends RuntimeException {
+
+    public InvalidPayloadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/exemptions/delta/ChsDeltaDeserialiserTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/delta/ChsDeltaDeserialiserTest.java
@@ -57,6 +57,7 @@ class ChsDeltaDeserialiserTest {
 
         // then
         InvalidPayloadException exception = assertThrows(InvalidPayloadException.class, actual);
+        // Note the '\n' is the length prefix of the invalid data sent to the deserialiser
         assertThat(exception.getMessage(), is(equalTo("Invalid payload: [\nhello] was provided.")));
         assertThat(exception.getCause(), is(CoreMatchers.instanceOf(IOException.class)));
     }

--- a/src/test/java/uk/gov/companieshouse/exemptions/delta/ChsDeltaDeserialiserTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/delta/ChsDeltaDeserialiserTest.java
@@ -43,8 +43,8 @@ class ChsDeltaDeserialiserTest {
     }
 
     @Test
-    @DisplayName("Return null if an IOException is thrown when deserialising a message")
-    void testDeserialiseDataReturnsNullIfIOExceptionThrown() throws IOException {
+    @DisplayName("Throws InvalidPayloadException if IOException encountered when deserialising a message")
+    void testDeserialiseDataThrowsInvalidPayloadExceptionlIfIOExceptionEncountered() throws IOException {
         // given
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         Encoder encoder = EncoderFactory.get().directBinaryEncoder(outputStream, null);
@@ -63,8 +63,8 @@ class ChsDeltaDeserialiserTest {
     }
 
     @Test
-    @DisplayName("Return null if an AvroException is thrown when deserialising a message")
-    void testDeserialiseDataReturnsNullIfAvroRuntimeExceptionThrown() {
+    @DisplayName("Throws InvalidPayloadException if AvroRuntimeException encountered when deserialising a message")
+    void testDeserialiseDataThrowsInvalidPayloadExceptionlIfAvroRuntimeExceptionEncountered() {
         // given
         ChsDeltaDeserialiser deserialiser = new ChsDeltaDeserialiser();
 

--- a/src/test/java/uk/gov/companieshouse/exemptions/delta/ChsDeltaDeserialiserTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/delta/ChsDeltaDeserialiserTest.java
@@ -1,12 +1,15 @@
 package uk.gov.companieshouse.exemptions.delta;
 
+import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.reflect.ReflectDatumWriter;
 import org.apache.avro.specific.SpecificDatumWriter;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import uk.gov.companieshouse.delta.ChsDelta;
 
 import java.io.ByteArrayOutputStream;
@@ -17,6 +20,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ChsDeltaDeserialiserTest {
 
@@ -45,14 +49,16 @@ class ChsDeltaDeserialiserTest {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         Encoder encoder = EncoderFactory.get().directBinaryEncoder(outputStream, null);
         DatumWriter<String> writer = new SpecificDatumWriter<>(String.class);
-        writer.write("invalid", encoder);
+        writer.write("hello", encoder);
         ChsDeltaDeserialiser deserialiser = new ChsDeltaDeserialiser();
 
         // when
-        ChsDelta actual = deserialiser.deserialize("topic", outputStream.toByteArray());
+        Executable actual = () -> deserialiser.deserialize("topic", outputStream.toByteArray());
 
         // then
-        assertThat(actual, is(nullValue()));
+        InvalidPayloadException exception = assertThrows(InvalidPayloadException.class, actual);
+        assertThat(exception.getMessage(), is(equalTo("Invalid payload: [\nhello] was provided.")));
+        assertThat(exception.getCause(), is(CoreMatchers.instanceOf(IOException.class)));
     }
 
     @Test
@@ -62,9 +68,11 @@ class ChsDeltaDeserialiserTest {
         ChsDeltaDeserialiser deserialiser = new ChsDeltaDeserialiser();
 
         // when
-        ChsDelta actual = deserialiser.deserialize("topic", "invalid".getBytes(StandardCharsets.UTF_8));
+        Executable actual = () ->  deserialiser.deserialize("topic", "invalid".getBytes(StandardCharsets.UTF_8));
 
         // then
-        assertThat(actual, is(nullValue()));
+        InvalidPayloadException exception = assertThrows(InvalidPayloadException.class, actual);
+        assertThat(exception.getMessage(), is(equalTo("Invalid payload: [invalid] was provided.")));
+        assertThat(exception.getCause(), is(CoreMatchers.instanceOf(AvroRuntimeException.class)));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/exemptions/delta/ConsumerInvalidTopicTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/delta/ConsumerInvalidTopicTest.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.exemptions.delta;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
@@ -8,6 +10,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,18 +22,13 @@ import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import uk.gov.companieshouse.delta.ChsDelta;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 
 @SpringBootTest(classes = Application.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
@@ -42,7 +40,7 @@ import static org.mockito.Mockito.doThrow;
 @TestPropertySource(locations = "classpath:application-test_main_nonretryable.yml")
 @Import(TestConfig.class)
 @ActiveProfiles("test_main_nonretryable")
-public class ConsumerNonRetryableExceptionTest {
+public class ConsumerInvalidTopicTest {
 
     @Autowired
     private EmbeddedKafkaBroker embeddedKafkaBroker;
@@ -63,20 +61,17 @@ public class ConsumerNonRetryableExceptionTest {
     ChsDeltaDeserialiser chsDeltaDeserialiser;
 
     @Test
-    void testRepublishToInvalidMessageTopicIfNonRetryableExceptionThrown() throws InterruptedException, IOException {
+    void testPublishToInvalidMessageTopicIfInvalidDataDeserialised() throws InterruptedException, IOException, ExecutionException {
         //given
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         Encoder encoder = EncoderFactory.get().directBinaryEncoder(outputStream, null);
         DatumWriter<String> writer = new ReflectDatumWriter<>(String.class);
         writer.write("hello", encoder);
         embeddedKafkaBroker.consumeFromAllEmbeddedTopics(testConsumer);
-        //doThrow(InvalidPayloadException.class).when(chsDeltaDeserialiser).deserialize(any(), any());
 
         //when
-        testProducer.send(new ProducerRecord<>("echo", 0, System.currentTimeMillis(), "key", outputStream.toByteArray()));
-        if (!latch.await(300L, TimeUnit.SECONDS)) {
-            fail("Timed out waiting for latch");
-        }
+        Future<RecordMetadata> future = testProducer.send(new ProducerRecord<>("echo", 0, System.currentTimeMillis(), "key", outputStream.toByteArray()));
+        future.get();
         ConsumerRecords<?, ?> consumerRecords = KafkaTestUtils.getRecords(testConsumer, 10000L, 2);
 
         //then

--- a/src/test/java/uk/gov/companieshouse/exemptions/delta/ConsumerNonRetryableExceptionTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/delta/ConsumerNonRetryableExceptionTest.java
@@ -59,43 +59,22 @@ public class ConsumerNonRetryableExceptionTest {
     @MockBean
     private ServiceRouter router;
 
+    @MockBean
+    ChsDeltaDeserialiser chsDeltaDeserialiser;
+
     @Test
     void testRepublishToInvalidMessageTopicIfNonRetryableExceptionThrown() throws InterruptedException, IOException {
-        //given
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        Encoder encoder = EncoderFactory.get().directBinaryEncoder(outputStream, null);
-        DatumWriter<ChsDelta> writer = new ReflectDatumWriter<>(ChsDelta.class);
-        writer.write(new ChsDelta("{}", 0, "context_id", false), encoder);
-        embeddedKafkaBroker.consumeFromAllEmbeddedTopics(testConsumer);
-        //doThrow(NonRetryableException.class).when(router).route(any());
-
-        //when
-        testProducer.send(new ProducerRecord<>("echo", 0, System.currentTimeMillis(), "key", outputStream.toByteArray()));
-        if (!latch.await(30L, TimeUnit.SECONDS)) {
-            fail("Timed out waiting for latch");
-        }
-        ConsumerRecords<?, ?> consumerRecords = KafkaTestUtils.getRecords(testConsumer, 10000L, 2);
-
-        //then
-        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, "echo"), is(1));
-        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, "echo-echo-consumer-retry"), is(0));
-        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, "echo-echo-consumer-error"), is(0));
-        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, "echo-echo-consumer-invalid"), is(1));
-    }
-
-    @Test
-    void testInvalidTopicHandlesMalformedMessage() throws IOException, InterruptedException {
         //given
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         Encoder encoder = EncoderFactory.get().directBinaryEncoder(outputStream, null);
         DatumWriter<String> writer = new ReflectDatumWriter<>(String.class);
         writer.write("hello", encoder);
         embeddedKafkaBroker.consumeFromAllEmbeddedTopics(testConsumer);
-        //doThrow(NonRetryableException.class).when(router).route(any());
+        //doThrow(InvalidPayloadException.class).when(chsDeltaDeserialiser).deserialize(any(), any());
 
         //when
         testProducer.send(new ProducerRecord<>("echo", 0, System.currentTimeMillis(), "key", outputStream.toByteArray()));
-        if (!latch.await(30L, TimeUnit.SECONDS)) {
+        if (!latch.await(300L, TimeUnit.SECONDS)) {
             fail("Timed out waiting for latch");
         }
         ConsumerRecords<?, ?> consumerRecords = KafkaTestUtils.getRecords(testConsumer, 10000L, 2);
@@ -105,6 +84,5 @@ public class ConsumerNonRetryableExceptionTest {
         assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, "echo-echo-consumer-retry"), is(0));
         assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, "echo-echo-consumer-error"), is(0));
         assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, "echo-echo-consumer-invalid"), is(1));
-
     }
 }

--- a/src/test/java/uk/gov/companieshouse/exemptions/delta/ConsumerNonRetryableExceptionTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/delta/ConsumerNonRetryableExceptionTest.java
@@ -67,7 +67,7 @@ public class ConsumerNonRetryableExceptionTest {
         DatumWriter<ChsDelta> writer = new ReflectDatumWriter<>(ChsDelta.class);
         writer.write(new ChsDelta("{}", 0, "context_id", false), encoder);
         embeddedKafkaBroker.consumeFromAllEmbeddedTopics(testConsumer);
-        doThrow(NonRetryableException.class).when(router).route(any());
+        //doThrow(NonRetryableException.class).when(router).route(any());
 
         //when
         testProducer.send(new ProducerRecord<>("echo", 0, System.currentTimeMillis(), "key", outputStream.toByteArray()));

--- a/src/test/java/uk/gov/companieshouse/exemptions/delta/ConsumerNonRetryableExceptionTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/delta/ConsumerNonRetryableExceptionTest.java
@@ -1,0 +1,85 @@
+package uk.gov.companieshouse.exemptions.delta;
+
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.reflect.ReflectDatumWriter;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.companieshouse.delta.ChsDelta;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+
+@SpringBootTest(classes = Application.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@EmbeddedKafka(
+        topics = {"echo", "echo-echo-consumer-retry", "echo-echo-consumer-error", "echo-echo-consumer-invalid"},
+        controlledShutdown = true,
+        partitions = 1
+)
+@TestPropertySource(locations = "classpath:application-test_main_nonretryable.yml")
+@Import(TestConfig.class)
+@ActiveProfiles("test_main_nonretryable")
+public class ConsumerNonRetryableExceptionTest {
+
+    @Autowired
+    private EmbeddedKafkaBroker embeddedKafkaBroker;
+
+    @Autowired
+    private KafkaConsumer<String, byte[]> testConsumer;
+
+    @Autowired
+    private KafkaProducer<String, byte[]> testProducer;
+
+    @Autowired
+    private CountDownLatch latch;
+
+    @MockBean
+    private ServiceRouter router;
+
+    @Test
+    void testRepublishToInvalidMessageTopicIfNonRetryableExceptionThrown() throws InterruptedException, IOException {
+        //given
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        Encoder encoder = EncoderFactory.get().directBinaryEncoder(outputStream, null);
+        DatumWriter<ChsDelta> writer = new ReflectDatumWriter<>(ChsDelta.class);
+        writer.write(new ChsDelta("{}", 0, "context_id", false), encoder);
+        embeddedKafkaBroker.consumeFromAllEmbeddedTopics(testConsumer);
+        doThrow(NonRetryableException.class).when(router).route(any());
+
+        //when
+        testProducer.send(new ProducerRecord<>("echo", 0, System.currentTimeMillis(), "key", outputStream.toByteArray()));
+        if (!latch.await(30L, TimeUnit.SECONDS)) {
+            fail("Timed out waiting for latch");
+        }
+        ConsumerRecords<?, ?> consumerRecords = KafkaTestUtils.getRecords(testConsumer, 10000L, 2);
+
+        //then
+        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, "echo"), is(1));
+        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, "echo-echo-consumer-retry"), is(0));
+        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, "echo-echo-consumer-error"), is(1));
+        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, "echo-echo-consumer-invalid"), is(0));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/exemptions/delta/InvalidMessageRouterTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/delta/InvalidMessageRouterTest.java
@@ -45,7 +45,7 @@ public class InvalidMessageRouterTest {
     }
 
     @Test
-    void testOnSendRoutesMessageToInvalidMessageTopicIfNonRetryableExceptionThrown() {
+    void testOnSendRoutesMessageToInvalidMessageTopicIfInvalidPayloadExceptionThrown() {
         // given
         ProducerRecord<String, ChsDelta> message = new ProducerRecord<>("main", 0, "key", delta,
                 List.of(
@@ -66,7 +66,7 @@ public class InvalidMessageRouterTest {
     }
 
     @Test
-    void testOnSendRoutesMessageToInvalidMessageTopicIfNonRetryableExceptionThrownNoHeaders() {
+    void testOnSendRoutesMessageToInvalidMessageTopicIfInvalidPayloadExceptionThrownNoHeaders() {
         // given
         ProducerRecord<String, ChsDelta> message = new ProducerRecord<>("main",  "key", delta);
 


### PR DESCRIPTION
- Throw runtime exception to stop infinite loop
- Create custom exception: InvalidPayloadException
- Remove latch from ConsumerNonRetryableExceptionTest

Resolves [DSND-1437](https://companieshouse.atlassian.net/browse/DSND-1437)

[DSND-1437]: https://companieshouse.atlassian.net/browse/DSND-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ