### PR TITLE
DSND-1481 - Modify invalid message router resilience

### DIFF
--- a/src/main/java/uk/gov/companieshouse/exemptions/delta/NonRetryableException.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/delta/NonRetryableException.java
@@ -8,4 +8,8 @@ public class NonRetryableException extends RuntimeException {
     public NonRetryableException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    public NonRetryableException(String message) {
+        super(message);
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/exemptions/delta/ConsumerInvalidTopicTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/delta/ConsumerInvalidTopicTest.java
@@ -40,7 +40,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @TestPropertySource(locations = "classpath:application-test_main_nonretryable.yml")
 @Import(TestConfig.class)
 @ActiveProfiles("test_main_nonretryable")
-public class ConsumerInvalidTopicTest {
+class ConsumerInvalidTopicTest {
 
     @Autowired
     private EmbeddedKafkaBroker embeddedKafkaBroker;
@@ -50,15 +50,6 @@ public class ConsumerInvalidTopicTest {
 
     @Autowired
     private KafkaProducer<String, byte[]> testProducer;
-
-    @Autowired
-    private CountDownLatch latch;
-
-    @MockBean
-    private ServiceRouter router;
-
-    @MockBean
-    ChsDeltaDeserialiser chsDeltaDeserialiser;
 
     @Test
     void testPublishToInvalidMessageTopicIfInvalidDataDeserialised() throws InterruptedException, IOException, ExecutionException {

--- a/src/test/java/uk/gov/companieshouse/exemptions/delta/ConsumerNonRetryableExceptionTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/delta/ConsumerNonRetryableExceptionTest.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.doThrow;
 @TestPropertySource(locations = "classpath:application-test_main_nonretryable.yml")
 @Import(TestConfig.class)
 @ActiveProfiles("test_main_nonretryable")
-public class ConsumerNonRetryableExceptionTest {
+class ConsumerNonRetryableExceptionTest {
 
     @Autowired
     private EmbeddedKafkaBroker embeddedKafkaBroker;
@@ -79,7 +79,7 @@ public class ConsumerNonRetryableExceptionTest {
         //then
         assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, "echo"), is(1));
         assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, "echo-echo-consumer-retry"), is(0));
-        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, "echo-echo-consumer-error"), is(1));
-        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, "echo-echo-consumer-invalid"), is(0));
+        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, "echo-echo-consumer-error"), is(0));
+        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, "echo-echo-consumer-invalid"), is(1));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/exemptions/delta/ErrorConsumerNonRetryableExceptionTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/delta/ErrorConsumerNonRetryableExceptionTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.verify;
 @TestPropertySource(locations = "classpath:application-test_error_negative.yml")
 @Import(TestConfig.class)
 @ActiveProfiles("test_error_negative")
-public class ErrorConsumerNonRetryableExceptionTest {
+class ErrorConsumerNonRetryableExceptionTest {
 
     @Autowired
     private EmbeddedKafkaBroker embeddedKafkaBroker;

--- a/src/test/java/uk/gov/companieshouse/exemptions/delta/ErrorConsumerRetryableExceptionTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/delta/ErrorConsumerRetryableExceptionTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.verify;
 @TestPropertySource(locations = "classpath:application-test_error_negative.yml")
 @Import(TestConfig.class)
 @ActiveProfiles("test_error_negative")
-public class ErrorConsumerRetryableExceptionTest {
+class ErrorConsumerRetryableExceptionTest {
 
     @Autowired
     private EmbeddedKafkaBroker embeddedKafkaBroker;

--- a/src/test/java/uk/gov/companieshouse/exemptions/delta/InvalidMessageRouterTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/delta/InvalidMessageRouterTest.java
@@ -8,7 +8,6 @@ import static org.springframework.kafka.support.KafkaHeaders.ORIGINAL_TOPIC;
 import java.math.BigInteger;
 import java.util.List;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,7 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class InvalidMessageRouterTest {
+class InvalidMessageRouterTest {
 
     private InvalidMessageRouter invalidMessageRouter;
 
@@ -55,7 +54,7 @@ public class InvalidMessageRouterTest {
                         new RecordHeader(EXCEPTION_MESSAGE, "[invalid]".getBytes())));
 
         ChsDelta invalidData = new ChsDelta(
-                "{ \"invalid_message\": \"payload: [ invalid ] passed for topic: main, partition: 0, offset: 1\" }",
+                "{ \"invalid_message\": \"exception: [ [invalid] ] passed for topic: main, partition: 0, offset: 1\" }",
                 0, "", false);
         // when
         ProducerRecord<String, ChsDelta> actual = invalidMessageRouter.onSend(message);
@@ -71,7 +70,7 @@ public class InvalidMessageRouterTest {
         ProducerRecord<String, ChsDelta> message = new ProducerRecord<>("main",  "key", delta);
 
         ChsDelta invalidData = new ChsDelta(
-                "{ \"invalid_message\": \"payload: [ unknown ] passed for topic: unknown, partition: -1, offset: -1\" }",
+                "{ \"invalid_message\": \"exception: [ unknown ] passed for topic: unknown, partition: -1, offset: -1\" }",
                 0, "", false);
         // when
         ProducerRecord<String, ChsDelta> actual = invalidMessageRouter.onSend(message);


### PR DESCRIPTION
* Improves resilience in invalid message router.
* Add null checks to error consumer.
* Refactor unit tests.

[DSND-1481](https://companieshouse.atlassian.net/browse/DSND-1481)



[DSND-1481]: https://companieshouse.atlassian.net/browse/DSND-1481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ