### PR TITLE
DSND-3109: Add delta at to delete test data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>1.3.1</version>
+        <version>2.1.6</version>
     </parent>
 
     <name>company-exemptions-delta-consumer</name>
@@ -24,7 +24,7 @@
         <cucumber.version>7.8.1</cucumber.version>
         <jib.version>3.0.0</jib.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
-        <private-api-sdk-java.version>2.0.196</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.443</private-api-sdk-java.version>
         <kafka-models.version>1.0.29</kafka-models.version>
         <structured-logging.version>1.9.14</structured-logging.version>
         <mapstruct.version>1.5.3.Final</mapstruct.version>

--- a/src/itest/resources/fragments/delete_exemptions.json
+++ b/src/itest/resources/fragments/delete_exemptions.json
@@ -1,4 +1,5 @@
 {
   "company_number": "00006400",
-  "action": "DELETE"
+  "action": "DELETE",
+  "delta_at": "20230724093435661593"
 }


### PR DESCRIPTION
This PR updates the tests to ensure the consumer can handle a delta_at field on an incoming delete delta.

[DSND-3109](https://companieshouse.atlassian.net/browse/DSND-3109)

[DSND-3109]: https://companieshouse.atlassian.net/browse/DSND-3109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ