### PR TITLE
Asm 2310 address sec vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.12</version>
+        <version>2.1.14</version>
         <relativePath/>
     </parent>
 
@@ -25,7 +25,7 @@
         <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
         <jib-maven-plugin.version>3.4.4</jib-maven-plugin.version>
 
-        <spring.boot.version>3.5.7</spring.boot.version>
+        <spring.boot.version>4.0.6</spring.boot.version>
         <cucumber.version>7.20.1</cucumber.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <avro.version>1.12.0</avro.version>
@@ -39,16 +39,33 @@
         <private-api-sdk-java.version>4.0.270</private-api-sdk-java.version>
         <api-sdk-java.version>6.0.37</api-sdk-java.version>
         <kafka-models.version>3.0.10</kafka-models.version>
-        <structured-logging.version>3.0.40</structured-logging.version>
+        <structured-logging.version>3.0.57</structured-logging.version>
       <commons-beanutils.version>1.11.0</commons-beanutils.version>
       <scala-library.version>2.13.9</scala-library.version>
       <commons-compress.version>1.26.0</commons-compress.version>
       <guava.version>32.0.1-android</guava.version>
       <commons-io.version>2.14.0</commons-io.version>
+
+        <ch-boms.version>0.1.5</ch-boms.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>uk.gov.companieshouse</groupId>
+                <artifactId>ch-core-bom</artifactId>
+                <version>${ch-boms.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>uk.gov.companieshouse</groupId>
+                <artifactId>ch-test-bom</artifactId>
+                <version>${ch-boms.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -197,7 +214,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-aop</artifactId>
+            <artifactId>spring-boot-starter-aspectj</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,25 +28,39 @@
         <spring.boot.version>4.0.6</spring.boot.version>
         <cucumber.version>7.20.1</cucumber.version>
         <mapstruct.version>1.6.3</mapstruct.version>
-        <avro.version>1.12.0</avro.version>
-        <test-containers.version>1.20.4</test-containers.version>
+        <avro.version>1.12.1</avro.version>
+        <test-containers.version>2.0.4</test-containers.version>
         <wiremock.version>3.10.0</wiremock.version>
         <junit-platform-suite.version>1.11.4</junit-platform-suite.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <grpc-context.version>1.75.0</grpc-context.version>
 
         <!-- internal dependencies -->
-        <private-api-sdk-java.version>4.0.270</private-api-sdk-java.version>
-        <api-sdk-java.version>6.0.37</api-sdk-java.version>
+        <private-api-sdk-java.version>6.0.23</private-api-sdk-java.version>
+        <api-sdk-java.version>6.6.23</api-sdk-java.version>
         <kafka-models.version>3.0.10</kafka-models.version>
         <structured-logging.version>3.0.57</structured-logging.version>
-      <commons-beanutils.version>1.11.0</commons-beanutils.version>
-      <scala-library.version>2.13.9</scala-library.version>
-      <commons-compress.version>1.26.0</commons-compress.version>
-      <guava.version>32.0.1-android</guava.version>
-      <commons-io.version>2.14.0</commons-io.version>
+        <commons-beanutils.version>1.11.0</commons-beanutils.version>
+        <scala-library.version>2.13.9</scala-library.version>
+        <commons-compress.version>1.26.0</commons-compress.version>
+        <guava.version>32.0.1-android</guava.version>
+        <commons-io.version>2.14.0</commons-io.version>
 
         <ch-boms.version>0.1.5</ch-boms.version>
+
+        <!-- sonar config -->
+        <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
+        <sonar.java.binaries>${project.basedir}/target,${project.basedir}/target/*</sonar.java.binaries>
+        <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
+        <sonar.login></sonar.login>
+        <sonar.password></sonar.password>
+        <sonar.projectKey>uk.gov.companieshouse:company-exemptions-delta-consumer</sonar.projectKey>
+        <sonar.projectName>company-exemptions-delta-consumer</sonar.projectName>
+
+        <opentelemetry.version>2.28.1</opentelemetry.version>
+
+        <kotlin-stdlin-override.version>2.3.21</kotlin-stdlin-override.version>
+        <jackson-bom.version>3.2.0</jackson-bom.version>
     </properties>
 
     <dependencyManagement>
@@ -66,13 +80,29 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
             <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring.boot.version}</version>
+                <groupId>tools.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
+            <dependency>
+                <groupId>io.opentelemetry.instrumentation</groupId>
+                <artifactId>opentelemetry-instrumentation-bom</artifactId>
+                <version>${opentelemetry.version}</version>
+                <type>pom</type>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                </exclusions>
+                <scope>import</scope>
+            </dependency>
+
             <dependency>
                 <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-bom</artifactId>
@@ -81,66 +111,80 @@
                 <scope>import</scope>
             </dependency>
 
-            <!-- CVE-2025-48924 -->
             <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${commons-lang3.version}</version> <!-- Use the latest available version -->
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
-
-            <!-- CVE-2024-11407 & CVE-2024-7246 -->
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-context</artifactId>
-                <version>${grpc-context.version}</version> <!-- Use the latest available version -->
-            </dependency>
-
-          <!-- CVE-2025-48734(8.8) -->
-          <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-            <version>${commons-beanutils.version}</version>
-          </dependency>
-
-          <!-- CVE-2022-36944 (9.8) -->
-          <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-            <version>${scala-library.version}</version>
-          </dependency>
-
-          <!-- CVE-2024-25710(8.1) -->
-          <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>${commons-compress.version}</version>
-          </dependency>
-
-          <!-- CVE-2023-2976(5.5) -->
-          <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-          </dependency>
-
-          <!-- CVE-2024-47554(4.3) -->
-          <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>${commons-io.version}</version>
-          </dependency>
         </dependencies>
     </dependencyManagement>
+
     <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.22</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin-stdlin-override.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-spring-boot-starter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib</artifactId>
+                </exclusion>
+                <!-- SB4, Jackson 3 -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>api-sdk-java</artifactId>
             <version>${api-sdk-java.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-datatype-jsr310</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>private-api-sdk-java</artifactId>
             <version>${private-api-sdk-java.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
@@ -189,19 +233,6 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>structured-logging</artifactId>
             <version>${structured-logging.version}</version>
-            <!-- Seems to be required for tests to pass with certain spring boot version -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-simple</artifactId>
-                </exclusion>
-
-                <!-- CVE-2025-48924 -->
-                <exclusion>
-                    <groupId>commons-lang</groupId>
-                    <artifactId>commons-lang</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mapstruct</groupId>
@@ -222,11 +253,19 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-kafka</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -236,6 +275,14 @@
                 <exclusion>
                     <groupId>net.minidev</groupId>
                     <artifactId>json-smart</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -251,8 +298,50 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-handler</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-csv</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-dataformat-jdk8</artifactId>
+                </exclusion>
             </exclusions>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jackson</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jackson-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test-autoconfigure</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-code</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
@@ -271,8 +360,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>kafka</artifactId>
-            <version>${test-containers.version}</version>
+            <artifactId>testcontainers-kafka</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -283,9 +371,8 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${test-containers.version}</version>
-            <scope>test</scope>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+           <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
@@ -298,7 +385,24 @@
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jsr310</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.22.0</version>
+        </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>
@@ -334,10 +438,6 @@
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <skipTests>${skip.unit.tests}</skipTests>
-                    <excludes>
-                        <exclude>**/Runner.java</exclude>
-                    </excludes>
-                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -360,9 +460,6 @@
                         </configurationParameters>
                     </properties>
                     <skipITs>${skip.integration.tests}</skipITs>
-                    <includes>
-                        <include>**/Runner.java</include>
-                    </includes>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/itest/java/uk/gov/companieshouse/exemptions/delta/config/Configuration.java
+++ b/src/itest/java/uk/gov/companieshouse/exemptions/delta/config/Configuration.java
@@ -1,13 +1,13 @@
 package uk.gov.companieshouse.exemptions.delta.config;
 
 import io.cucumber.spring.CucumberContextConfiguration;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 import uk.gov.companieshouse.exemptions.delta.kafka.TestKafkaConfig;
 
@@ -18,8 +18,8 @@ import uk.gov.companieshouse.exemptions.delta.kafka.TestKafkaConfig;
 @ActiveProfiles("integration_tests")
 public class Configuration {
 
-    public static final KafkaContainer kafkaContainer = new KafkaContainer(
-            DockerImageName.parse("confluentinc/cp-kafka:5.0.0"));
+    public static final ConfluentKafkaContainer kafkaContainer = new ConfluentKafkaContainer(
+            DockerImageName.parse("confluentinc/cp-kafka:7.8.0"));
 
 
     @DynamicPropertySource

--- a/src/main/java/uk/gov/companieshouse/exemptions/delta/kafka/CompanyExemptionsDeltaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/delta/kafka/CompanyExemptionsDeltaConsumer.java
@@ -1,12 +1,12 @@
 package uk.gov.companieshouse.exemptions.delta.kafka;
 
+import org.springframework.kafka.annotation.BackOff;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.annotation.RetryableTopic;
 import org.springframework.kafka.listener.ConsumerSeekAware;
 import org.springframework.kafka.retrytopic.DltStrategy;
 import org.springframework.kafka.retrytopic.SameIntervalTopicReuseStrategy;
 import org.springframework.messaging.Message;
-import org.springframework.retry.annotation.Backoff;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.delta.ChsDelta;
 import uk.gov.companieshouse.exemptions.delta.exception.RetryableException;
@@ -42,7 +42,7 @@ public class CompanyExemptionsDeltaConsumer implements ConsumerSeekAware {
     @RetryableTopic(
             attempts = "${consumer.max_attempts}",
             autoCreateTopics = "false",
-            backoff = @Backoff(delayExpression = "${consumer.backoff_delay}"),
+            backOff = @BackOff(delayString = "${consumer.backoff_delay}"),
             retryTopicSuffix = "-${consumer.group_id}-retry",
             dltTopicSuffix = "-${consumer.group_id}-error",
             dltStrategy = DltStrategy.FAIL_ON_ERROR,

--- a/src/main/java/uk/gov/companieshouse/exemptions/delta/kafka/MessageFlags.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/delta/kafka/MessageFlags.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.exemptions.delta.kafka;
 
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PreDestroy;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/uk/gov/companieshouse/exemptions/delta/service/delete/DeleteContentFilter.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/delta/service/delete/DeleteContentFilter.java
@@ -1,8 +1,8 @@
 package uk.gov.companieshouse.exemptions.delta.service.delete;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.api.delta.PscExemptionDeleteDelta;
 import uk.gov.companieshouse.delta.ChsDelta;
 import uk.gov.companieshouse.exemptions.delta.exception.NonRetryableException;
@@ -28,7 +28,7 @@ class DeleteContentFilter {
     PscExemptionDeleteDelta filter(ChsDelta delta) {
         try {
             return objectMapper.readValue(delta.getData(), PscExemptionDeleteDelta.class);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new NonRetryableException("Error extracting exemption delete delta", e);
         }
     }

--- a/src/main/java/uk/gov/companieshouse/exemptions/delta/service/upsert/UpsertContentFilter.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/delta/service/upsert/UpsertContentFilter.java
@@ -1,8 +1,8 @@
 package uk.gov.companieshouse.exemptions.delta.service.upsert;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.api.delta.PscExemptionDelta;
 import uk.gov.companieshouse.delta.ChsDelta;
 import uk.gov.companieshouse.exemptions.delta.exception.NonRetryableException;
@@ -28,7 +28,7 @@ class UpsertContentFilter {
     PscExemptionDelta filter(ChsDelta delta) {
         try {
             return mapper.readValue(delta.getData(), PscExemptionDelta.class);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new NonRetryableException("Error extracting exemption delta", e);
         }
     }

--- a/src/test/java/uk/gov/companieshouse/exemptions/delta/kafka/AbstractKafkaTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/delta/kafka/AbstractKafkaTest.java
@@ -1,9 +1,9 @@
 package uk.gov.companieshouse.exemptions.delta.kafka;
 
 import org.springframework.context.annotation.Import;
-import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
@@ -11,5 +11,5 @@ import org.testcontainers.utility.DockerImageName;
 public abstract class AbstractKafkaTest {
 
     @Container
-    public static final KafkaContainer kafkaContainer = new KafkaContainer(
-            DockerImageName.parse("confluentinc/cp-kafka:5.0.0"));}
+    public static final ConfluentKafkaContainer kafkaContainer = new ConfluentKafkaContainer(
+            DockerImageName.parse("confluentinc/cp-kafka:7.8.0"));}

--- a/src/test/java/uk/gov/companieshouse/exemptions/delta/service/delete/DeleteContentFilterTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/delta/service/delete/DeleteContentFilterTest.java
@@ -6,22 +6,22 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.api.delta.PscExemptionDeleteDelta;
 import uk.gov.companieshouse.delta.ChsDelta;
 import uk.gov.companieshouse.exemptions.delta.exception.NonRetryableException;
 
-public class DeleteContentFilterTest {
+class DeleteContentFilterTest {
 
     @Test
     void testExtractPscExemptionDeleteDeltaFromChsDelta() {
         // given
-        ChsDelta delta = new ChsDelta("{\"action\": \"DELETE\", \"company_number\": \"12345678\"}",
+        final var delta = new ChsDelta("{\"action\": \"DELETE\", \"company_number\": \"12345678\"}",
                 0, "context_id", true);
-        DeleteContentFilter filter = new DeleteContentFilter(new ObjectMapper());
+        final var filter = new DeleteContentFilter(new ObjectMapper());
 
         // when
         PscExemptionDeleteDelta data = filter.filter(delta);
@@ -33,21 +33,21 @@ public class DeleteContentFilterTest {
     @Test
     void testThrowNonRetryableExceptionIfJsonMalformed() {
         // given
-        ChsDelta delta = new ChsDelta("{[",
+        final var delta = new ChsDelta("{[",
                 0, "context_id", true);
-        DeleteContentFilter filter = new DeleteContentFilter(new ObjectMapper());
+        final var filter = new DeleteContentFilter(new ObjectMapper());
 
         // when
-        Executable actual = () -> filter.filter(delta);
+        final Executable actual = () -> filter.filter(delta);
 
         // then
-        NonRetryableException exception = assertThrows(NonRetryableException.class, actual);
+        final var exception = assertThrows(NonRetryableException.class, actual);
         assertThat(exception.getMessage(), is(equalTo("Error extracting exemption delete delta")));
-        assertThat(exception.getCause(), is(instanceOf(JsonProcessingException.class)));
+        assertThat(exception.getCause(), is(instanceOf(JacksonException.class)));
     }
 
     private PscExemptionDeleteDelta expectedExemptionDeleteDelta() {
-        PscExemptionDeleteDelta result = new PscExemptionDeleteDelta();
+        final var result = new PscExemptionDeleteDelta();
         result.setAction(PscExemptionDeleteDelta.ActionEnum.DELETE);
         result.setCompanyNumber("12345678");
         return result;

--- a/src/test/java/uk/gov/companieshouse/exemptions/delta/service/upsert/UpsertContentFilterTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/delta/service/upsert/UpsertContentFilterTest.java
@@ -6,10 +6,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.api.delta.PscExemptionDelta;
 import uk.gov.companieshouse.delta.ChsDelta;
 import uk.gov.companieshouse.exemptions.delta.exception.NonRetryableException;
@@ -39,6 +39,6 @@ class UpsertContentFilterTest {
         // then
         NonRetryableException exception = assertThrows(NonRetryableException.class, actual);
         assertThat(exception.getMessage(), is(equalTo("Error extracting exemption delta")));
-        assertThat(exception.getCause(), is(instanceOf(JsonProcessingException.class)));
+        assertThat(exception.getCause(), is(instanceOf(JacksonException.class)));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/exemptions/delta/service/upsert/UpsertRequestMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/delta/service/upsert/UpsertRequestMapperTest.java
@@ -2,13 +2,13 @@ package uk.gov.companieshouse.exemptions.delta.service.upsert;
 
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
-import com.fasterxml.jackson.databind.util.StdDateFormat;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 import org.apache.commons.io.IOUtils;
 import org.json.JSONException;
 import org.junit.jupiter.api.DisplayName;
@@ -17,11 +17,12 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import tools.jackson.databind.util.StdDateFormat;
 import uk.gov.companieshouse.api.delta.PscExemptionDelta;
 
 @SpringBootTest(classes = UpsertRequestMapperImpl.class)
 @DisplayName("Upsert request mapper")
-public class UpsertRequestMapperTest {
+class UpsertRequestMapperTest {
 
     @Autowired
     private UpsertRequestMapper requestMapper;
@@ -33,10 +34,12 @@ public class UpsertRequestMapperTest {
         // given
         String input = IOUtils.resourceToString("/examples/" + feature + "/input.json", StandardCharsets.UTF_8);
         String expected = IOUtils.resourceToString("/examples/" + feature + "/output.json", StandardCharsets.UTF_8);
-        ObjectMapper mapper = new ObjectMapper()
-                .setAnnotationIntrospector(new JacksonAnnotationIntrospector())
-                .registerModule(new JavaTimeModule())
-                .setDateFormat(new StdDateFormat());
+        final var mapper =
+                JsonMapper
+                        .builder()
+                        .defaultDateFormat(new StdDateFormat())
+                        .addModule(new JavaTimeModule())
+                        .build();
         PscExemptionDelta delta = mapper.readValue(input, PscExemptionDelta.class);
 
         // when


### PR DESCRIPTION
Sec Vuln Fixes.

CVE-2025-11143(6.5)
CVE-2026-2332(9.1)
CVE-2026-5795(7.4)
CVE-2026-1605(7.5)
CVE-2026-33558(5.3)
CVE-2026-34477(6.3)
CVE-2026-34479(6.9)
CVE-2026-40977(6.7)
CVE-2026-40971(9.1)
CVE-2026-40972(7.5)
CVE-2026-40975(7.5)
CVE-2026-22733(8.1)
CVE-2026-40973(7.0)
CVE-2026-22731(8.1)
CVE-2026-40974(9.8)
CVE-2026-22740(6.5)
CVE-2026-22737(5.9)
CVE-2026-22745(5.3)                                                                                          
CVE-2026-24734(7.5)
CVE-2026-41293(9.8)
CVE-2026-41284(7.5)
CVE-2025-66614(9.1)
CVE-2026-34500(6.5)
CVE-2026-34487(7.5)
CVE-2026-29145(9.1)
CVE-2026-29146(7.5)
CVE-2026-34483(7.5),
CVE-2026-43513(7.5),
CVE-2026-24880(7.5)
CVE-2026-43512(9.8)
CVE-2026-42498(7.3)
CVE-2026-43515(9.1)
CVE-2026-25854(6.1) 

 Spring Boot 4, Jackson 3 upgrades.

* Updated parent pom.
* Updated spring boot version to 4
* Added ch internal boms.
* Updated Jackson 2 to 3.
* Updated KafkaContainer to ConfluentKafkaContainer.