### PR TITLE
Removed use of `SERVER_PORT` to define value for `server.port`

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: ${SERVER_PORT:8081}
+  port: 8081
 
 spring:
   kafka:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,3 @@
-server:
-  port: 8081
-
 spring:
   kafka:
     bootstrap-servers: ${BOOTSTRAP_SERVER_URL:localhost:9092}


### PR DESCRIPTION
This pull request makes a minor configuration update to the `application.yml` file, setting the server port to a fixed value of 8081 instead of using the environment variable `SERVER_PORT`.

Defining `SERVER_PORT` in the environment config will automatically override `server.port` as thats how springs externalised configuration mechanism works.  

This was changed as the server was failing to start on the configured port due to a clash with springs own override mechanism.

